### PR TITLE
Fixing display of the ADF timer

### DIFF
--- a/Models/Interior/Panel/Instruments/kr87-adf/kr87.xml
+++ b/Models/Interior/Panel/Instruments/kr87-adf/kr87.xml
@@ -7,7 +7,6 @@
         <dimming>instrumentation/adf[0]/dimming-norm</dimming>
         <dial-1-khz>instrumentation/adf[0]/frequencies/dial-1-khz</dial-1-khz>
         <dial-100-khz>instrumentation/adf[0]/frequencies/dial-100-khz</dial-100-khz>
-
     </params>
 
     <path>kr87.ac</path>
@@ -246,7 +245,7 @@
         <object-name>indicator.Stby.1000</object-name>
         <condition>
             <greater-than-equals>
-                <property>/instrumentation/adf[0]/frequencies/standby-khz</property>
+                <property alias="../../../../params/right-display"/>
                 <value type="int">1000</value>
             </greater-than-equals>
         </condition>
@@ -255,7 +254,7 @@
     <animation>
         <type>textranslate</type>
         <object-name>indicator.Stby.1000</object-name>
-        <property>/instrumentation/adf[0]/frequencies/standby-khz</property>
+        <property alias="../../params/right-display"/>
         <step>1000</step>
         <factor>0.0001</factor>
         <axis>
@@ -268,7 +267,7 @@
     <animation>
         <type>textranslate</type>
         <object-name>indicator.Stby.100</object-name>
-        <property>/instrumentation/adf[0]/frequencies/standby-khz</property>
+        <property alias="../../params/right-display"/>
         <step>100</step>
         <factor>0.001</factor>
         <axis>
@@ -281,7 +280,7 @@
     <animation>
         <type>textranslate</type>
         <object-name>indicator.Stby.10</object-name>
-        <property>/instrumentation/adf[0]/frequencies/standby-khz</property>
+        <property alias="../../params/right-display"/>
         <step>10</step>
         <factor>0.01</factor>
         <axis>
@@ -294,7 +293,7 @@
     <animation>
         <type>textranslate</type>
         <object-name>indicator.Stby.1</object-name>
-        <property>/instrumentation/adf[0]/frequencies/standby-khz</property>
+        <property alias="../../params/right-display"/>
         <step>1</step>
         <factor>0.1</factor>
         <axis>


### PR DESCRIPTION
Solves #885 

Basically, I broke that display in the commit https://github.com/c172p-team/c172p-detailed/commit/5bb4bb618a9467cc720a2fc7adb582a11c49fc8e

I am creating this PR rather than reverting it because 1) @onox has made other modifications to this same file after that commit and 2) I also had removed some unnecessary lines of code in that fateful commit, so this had to be done manually. Please see the issue description for more information.