### PR TITLE
Carburettor icing and other engine related improvements

### DIFF
--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -58,7 +58,7 @@ var autostart = func (msg=1) {
     var oil_enabled = getprop("/engines/active-engine/oil_consumption_allowed");
     var oil_level   = getprop("/engines/active-engine/oil-level");
     
-    if (oil_enabled and oil_level < 6.0) {
+    if (oil_enabled and oil_level < 5.0) {
         if (getprop("/controls/engines/active-engine") == 0) {
             setprop("/engines/active-engine/oil-level", 7.0);
         } 

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -149,23 +149,25 @@ var carb_icing_function = maketimer(1.0, func {
         var dewpointF = dewpointC * 9.0 / 5.0 + 32;
         var airtempF = getprop("/environment/temperature-degf");
         var oil_temp = getprop("/engines/active-engine/oil-temperature-degf");
-        var egt_norm = getprop("/engines/active-engine/egt-norm");
+        var egt_degf = getprop("/engines/active-engine/egt-degf");
         
         # the formula below attempts to modle the graph found in the POH, using RPM, airtempF and dewpointF as variables
+        # carb_icing_formula ranges from 0.0008 to -0.0002
         var factorX = 13.2 - 3.2 * math.atan2 ( ((rpm - 2000.0) * 0.008), 1);
         var factorY = 7.0 - 2.0 * math.atan2 ( ((rpm - 2000.0) * 0.008), 1);
-        var carb_icing_formula = 0.01 * (math.exp( math.pow((0.6 * airtempF + 0.3 * dewpointF - 42.0),2) / (-2 * math.pow(factorX,2))) * math.exp( math.pow((0.3 * airtempF - 0.6 * dewpointF + 14.0),2) / (-2 * math.pow(factorY,2))) - 0.2);
+        var carb_icing_formula = 0.001 * (math.exp( math.pow((0.6 * airtempF + 0.3 * dewpointF - 42.0),2) / (-2 * math.pow(factorX,2))) * math.exp( math.pow((0.3 * airtempF - 0.6 * dewpointF + 14.0),2) / (-2 * math.pow(factorY,2))) - 0.2);
         
-        # if carb heat on, the rate decreses by a certain amount
-        if (getprop("/engines/active-engine/running") and getprop("/controls/engines/current-engine/carb-heat"))
-            var carb_heat_rate = -0.03 * egt_norm;
+        # with carb heat on and a typical EGT of ~1450, the carb_heat_rate will be around -0.0012
+        if (getprop("/controls/engines/current-engine/carb-heat"))
+            var carb_heat_rate = -0.00000085 * egt_degf;
         else
             var carb_heat_rate = 0.0;
         
         # carb icing rate is multiplied by an oil temp factor so a cold engine doens't accumulate ice
+        # oil_temp_factor ranges from 0 to ~1.5
         var oil_temp_factor = (oil_temp - 60) / 200;
         oil_temp_factor = std.max(0.0, std.min(oil_temp_factor, 1.0));
-        var carb_icing_rate = oil_temp_factor * (carb_icing_formula + carb_heat_rate);
+        var carb_icing_rate = oil_temp_factor * carb_icing_formula + carb_heat_rate;
 
         var carb_ice = getprop("/engines/active-engine/carb_ice");
         carb_ice = carb_ice + carb_icing_rate;

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -212,7 +212,7 @@ var engine_coughing = func(){
     # if coughing due to fuel contamination, then cough interval depends on quantity of water
     var water_contamination0 = getprop("/consumables/fuel/tank[0]/water-contamination");
     var water_contamination1 = getprop("/consumables/fuel/tank[1]/water-contamination");
-    var total_water_contamination = water_contamination0 + water_contamination1;
+    var total_water_contamination = std.min((water_contamination0 + water_contamination1), 0.4);
     if (total_water_contamination > 0) {
         # if contamination is near 0, then interval is between 17 and 20 seconds, but if contamination is near the 
         # engine stopping value of 0.4, then interval falls to around 0.5 and 3.5 seconds

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -163,7 +163,7 @@ var carb_icing_function = maketimer(1.0, func {
         else
             var carb_heat_rate = 0.0;
         
-        # carb icing rate is multiplied by an oil temp factor so a cold engine doens't accumulate ice
+        # a warm engine will accumulate less oil than a cold one, which is what oil temp factor is used for
         # oil_temp_factor ranges from 0 to aprox -0.2 (at 250 oF)
         var oil_temp_factor = oil_temp / -1250;
         var carb_icing_rate = carb_icing_formula + carb_heat_rate + oil_temp_factor;

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -150,12 +150,13 @@ var carb_icing_function = maketimer(1.0, func {
         var airtempF = getprop("/environment/temperature-degf");
         var oil_temp = getprop("/engines/active-engine/oil-temperature-degf");
         var egt_degf = getprop("/engines/active-engine/egt-degf");
+        var engine_running = getprop("/engines/active-engine/running");
         
         # the formula below attempts to modle the graph found in the POH, using RPM, airtempF and dewpointF as variables
         # carb_icing_formula ranges from 0.65 to -0.35
         var factorX = 13.2 - 3.2 * math.atan2 ( ((rpm - 2000.0) * 0.008), 1);
         var factorY = 7.0 - 2.0 * math.atan2 ( ((rpm - 2000.0) * 0.008), 1);
-        var carb_icing_formula = math.exp( math.pow((0.6 * airtempF + 0.3 * dewpointF - 42.0),2) / (-2 * math.pow(factorX,2))) * math.exp( math.pow((0.3 * airtempF - 0.6 * dewpointF + 14.0),2) / (-2 * math.pow(factorY,2))) - 0.35;
+        var carb_icing_formula = (math.exp( math.pow((0.6 * airtempF + 0.3 * dewpointF - 42.0),2) / (-2 * math.pow(factorX,2))) * math.exp( math.pow((0.3 * airtempF - 0.6 * dewpointF + 14.0),2) / (-2 * math.pow(factorY,2))) - 0.35)  * engine_running;
         
         # with carb heat on and a typical EGT of ~1450, the carb_heat_rate will be around -1.5
         if (getprop("/controls/engines/current-engine/carb-heat"))

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -118,15 +118,15 @@ var oil_consumption = maketimer(1.0, func {
         var low_oil_pressure_factor = 1.0;
         var low_oil_temperature_factor = 1.0;
 
-        # If oil gets low (< 5.0), pressure should drop and temperature should rise
-        var oil_level_limited = std.min(oil_level, 5.0);
+        # If oil gets low (< 3.0), pressure should drop and temperature should rise
+        var oil_level_limited = std.min(oil_level, 3.0);
     
-        # Should give 1.0 for oil_level = 5 and 0.1 for oil_level 4.92,
+        # Should give 1.0 for oil_level = 3 and 0.1 for oil_level 1.97,
         # which is the min before the engine stops
-        low_oil_pressure_factor = 11.25 * oil_level_limited - 55.25;
-    
-        # Should give 1.0 for oil_level = 5 and 1.5 for oil_level 4.92
-        low_oil_temperature_factor = -6.25 * oil_level_limited + 32.25;
+        low_oil_pressure_factor = 0.873786408 * oil_level_limited - 1.621359224;
+        
+        # Should give 1.0 for oil_level = 3 and 1.5 for oil_level 1.97
+        low_oil_temperature_factor = -0.485436893 * oil_level_limited + 2.456310679;
     
         setprop("/engines/active-engine/low-oil-pressure-factor", low_oil_pressure_factor);
         setprop("/engines/active-engine/low-oil-temperature-factor", low_oil_temperature_factor);

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -149,6 +149,7 @@ var carb_icing_function = maketimer(1.0, func {
         var dewpointF = dewpointC * 9.0 / 5.0 + 32;
         var airtempF = getprop("/environment/temperature-degf");
         var oil_temp = getprop("/engines/active-engine/oil-temperature-degf");
+        var egt_norm = getprop("/engines/active-engine/egt-norm");
         
         # the formula below attempts to modle the graph found in the POH, using RPM, airtempF and dewpointF as variables
         var factorX = 13.2 - 3.2 * math.atan2 ( ((rpm - 2000.0) * 0.008), 1);
@@ -157,12 +158,12 @@ var carb_icing_function = maketimer(1.0, func {
         
         # if carb heat on, the rate decreses by a certain amount
         if (getprop("/engines/active-engine/running") and getprop("/controls/engines/current-engine/carb-heat"))
-            var carb_heat_rate = -0.01;
+            var carb_heat_rate = -0.03 * egt_norm;
         else
             var carb_heat_rate = 0.0;
         
         # carb icing rate is multiplied by an oil temp factor so a cold engine doens't accumulate ice
-        var oil_temp_factor = (oil_temp - 120) / 100;
+        var oil_temp_factor = (oil_temp - 60) / 200;
         oil_temp_factor = std.max(0.0, std.min(oil_temp_factor, 1.0));
         var carb_icing_rate = oil_temp_factor * (carb_icing_formula + carb_heat_rate);
 

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -164,7 +164,7 @@ var carb_icing_function = maketimer(1.0, func {
         else
             var carb_heat_rate = 0.0;
         
-        # a warm engine will accumulate less oil than a cold one, which is what oil temp factor is used for
+        # a warm engine will accumulate less ice than a cold one, which is what oil temp factor is used for
         # oil_temp_factor ranges from 0 to aprox -0.2 (at 250 oF)
         var oil_temp_factor = oil_temp / -1250;
         var carb_icing_rate = carb_icing_formula + carb_heat_rate + oil_temp_factor;

--- a/Systems/engine.xml
+++ b/Systems/engine.xml
@@ -199,6 +199,32 @@
     </filter>
 
     <filter>
+        <name>Engine EGT Temp</name>
+        <type>gain</type>
+        <input>
+            <condition>
+                <equals>
+                    <property>/controls/engines/active-engine</property>
+                    <value>1</value>
+                </equals>
+            </condition>
+            <property>/engines/engine[1]/egt-degf</property>
+        </input>
+        <input>
+            <condition>
+                <equals>
+                    <property>/controls/engines/active-engine</property>
+                    <value>0</value>
+                </equals>
+            </condition>
+            <property>/engines/engine[0]/egt-degf</property>
+        </input>
+        <output>
+            <property>/engines/active-engine/egt-degf</property>
+        </output>
+    </filter>
+
+    <filter>
         <name>Engine EGT Norm</name>
         <type>gain</type>
         <input>
@@ -566,16 +592,6 @@
                     <less-than>
                         <property>/engines/active-engine/oil-level</property>
                         <value>4.925</value>
-                    </less-than>
-                </and>
-                <and>
-                    <greater-than-equals>
-                        <property>/engines/active-engine/carb_ice</property>
-                        <value>0.3</value>
-                    </greater-than-equals>
-                    <less-than>
-                        <property>/engines/active-engine/carb_ice</property>
-                        <value>0.32</value>
                     </less-than>
                 </and>
             </or>

--- a/Systems/engine.xml
+++ b/Systems/engine.xml
@@ -591,8 +591,12 @@
                     </greater-than>
                     <less-than>
                         <property>/engines/active-engine/carb_icing_rate</property>
-                        <value>0.0</value>
+                        <value>-0.5</value>
                     </less-than>
+                    <greater-than>
+                        <property>/engines/active-engine/egt-norm</property>
+                        <value>0.5</value>
+                    </greater-than>
                 </and>
             </or>
         </input>

--- a/Systems/engine.xml
+++ b/Systems/engine.xml
@@ -585,13 +585,13 @@
                     </not>
                 </and>
                 <and>
-                    <greater-than-equals>
-                        <property>/engines/active-engine/oil-level</property>
-                        <value>4.920</value>
-                    </greater-than-equals>
+                    <greater-than>
+                        <property>/engines/active-engine/carb_ice</property>
+                        <value>0.0</value>
+                    </greater-than>
                     <less-than>
-                        <property>/engines/active-engine/oil-level</property>
-                        <value>4.925</value>
+                        <property>/engines/active-engine/carb_icing_rate</property>
+                        <value>0.0</value>
                     </less-than>
                 </and>
             </or>

--- a/Systems/engine.xml
+++ b/Systems/engine.xml
@@ -530,7 +530,7 @@
                 </and>
                 <less-than>
                     <property>/engines/active-engine/oil-level</property>
-                    <value>4.92</value>
+                    <value>1.97</value>
                 </less-than>
                 <greater-than-equals>
                     <property>/engines/active-engine/carb_ice</property>

--- a/Systems/engine.xml
+++ b/Systems/engine.xml
@@ -513,7 +513,7 @@
                 <property>/engines/active-engine/crashed</property>
                 <property>/engines/active-engine/kill-engine</property>
 
-                <!-- High level of fuel contamination or low level of oil kills engine -->
+                <!-- engine is killed if fuel contamination is higher than 0.2 on a selected tank -->
                 <and>
                     <property>consumables/fuel/tank[0]/selected</property>
                     <greater-than>
@@ -528,10 +528,15 @@
                         <value>0.2</value>
                     </greater-than>
                 </and>
+                
+                <!-- engine is also killed if oil level is critical. Minimum oil level in the sump for safe operation (according 
+                to Lycommings manual, page 3-10) is 2 quarts, which explains the value of 1.97 below-->
                 <less-than>
                     <property>/engines/active-engine/oil-level</property>
                     <value>1.97</value>
                 </less-than>
+                
+                <!-- engine is also killed if there is too much ice in the carburettor. Limit value is arbitrarily set to 0.32 -->
                 <greater-than-equals>
                     <property>/engines/active-engine/carb_ice</property>
                     <value>0.32</value>
@@ -548,6 +553,8 @@
         <name>Engine Coughing</name>
         <input>
             <or>
+            
+                <!-- engine coughs if fuel contamination is present on a selected tank, but lower than the critical value of 0.2 -->
                 <and>
                     <or>
                         <and>
@@ -584,6 +591,8 @@
                         </and>
                     </not>
                 </and>
+                
+                <!-- engine also coughs if ice is present in the carburettor and is melting at a noticiable rate -->
                 <and>
                     <greater-than>
                         <property>/engines/active-engine/carb_ice</property>
@@ -593,6 +602,8 @@
                         <property>/engines/active-engine/carb_icing_rate</property>
                         <value>-0.5</value>
                     </less-than>
+                    <!-- leaning the mixture while the carb ice is melting helps with the cough in RL, which is why 
+                    the egt-norm property is used here -->
                     <greater-than>
                         <property>/engines/active-engine/egt-norm</property>
                         <value>0.5</value>


### PR DESCRIPTION
The carburetor icing system has been reviewed and several things have been improved:

- adjusted ice accumulation rate in icing conditions
- no ice accumulation when the engine is not running
- adjusted effectiveness of carburetor heat, which now is related to the engine exhaust temperature
- engine temperature affects ice formation (the warmer the engine, the lower the icing rate)
- the engine now coughs when the ice is melting, and the amount of coughing is proportional to the quantity of ice (i.e. severe icing accumulation == severe coughing)
- leaning when engine is coughing due to ice melting can help with coughing
- coughing can also happened due to fuel contamination with water, and the coughing interval is also proportional to the quantity of water
- lowered limit of critical oil level (when engine will quit) to below 2 quarts, according to Lycoming's manual
- critical oil will not cause the engine to cough, it will simply stop

Full discussion here: https://github.com/c172p-team/c172p-detailed/pull/826