### PR TITLE
bug-902

### DIFF
--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -52,8 +52,10 @@ var autostart = func (msg=1) {
 
     # Removing any contamination from water
     setprop("/consumables/fuel/tank[0]/water-contamination", 0.0);
-    setprop("/consumables/fuel/tank[1]/water-contamination", 0.0);        
-
+    setprop("/consumables/fuel/tank[1]/water-contamination", 0.0);
+    setprop("/consumables/fuel/tank[0]/sample-water-contamination", 0.0);
+    setprop("/consumables/fuel/tank[1]/sample-water-contamination", 0.0);
+    
     # Setting max oil level
     var oil_enabled = getprop("/engines/active-engine/oil_consumption_allowed");
     var oil_level   = getprop("/engines/active-engine/oil-level");
@@ -169,8 +171,10 @@ var take_fuel_sample = func(index) {
 
     # Remove a bit of water if contaminated
     if (water > 0.0) {
-        water = std.max(0.0, water - 0.2);
+        var sample_water = std.min(0.2, water);
+        water = water - sample_water;
         setprop("/consumables/fuel/tank", index, "water-contamination", water);
+        setprop("/consumables/fuel/tank", index, "sample-water-contamination", sample_water);
     };
 };
 
@@ -180,14 +184,16 @@ var take_fuel_sample = func(index) {
 var return_fuel_sample = func(index) {
     var fuel = getprop("/consumables/fuel/tank", index, "level-gal_us");
     var water = getprop("/consumables/fuel/tank", index, "water-contamination");
+    var sample_water = getprop("/consumables/fuel/tank", index, "sample-water-contamination");
 
     # Add back the 50 ml of fuel
     setprop("/consumables/fuel/tank", index, "level-gal_us", fuel + 0.0132086);
 
     # Add back the (contaminated) water
-    if (water > 0.0) {
-        water = std.min(water + 0.2, 1.0);
+    if (sample_water > 0.0) {
+        water = water + sample_water;
         setprop("/consumables/fuel/tank", index, "water-contamination", water);
+        setprop("/consumables/fuel/tank", index, "sample-water-contamination", 0.0);
     };
 };
 

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -539,6 +539,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
                 <level-gal_us type="double">20</level-gal_us>
                 <selected type="bool">true</selected>
                 <water-contamination type="double">0.0</water-contamination>
+                <sample-water-contamination type="double">0.0</sample-water-contamination>
                 <fuel-sample-taken type="bool">false</fuel-sample-taken>
             </tank>
             <tank n="1">
@@ -546,6 +547,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
                 <level-gal_us type="double">20</level-gal_us>
                 <selected type="bool">true</selected>
                 <water-contamination type="double">0.0</water-contamination>
+                <sample-water-contamination type="double">0.0</sample-water-contamination>
                 <fuel-sample-taken type="bool">false</fuel-sample-taken>
             </tank>
             <tank n="2">

--- a/gui/dialogs/c172p-left-fuel-sample.xml
+++ b/gui/dialogs/c172p-left-fuel-sample.xml
@@ -84,6 +84,11 @@
             </enable>
             <binding>
                 <command>property-assign</command>
+                <property>/consumables/fuel/tank[0]/sample-water-contamination</property>
+                <value>0.0</value>
+            </binding>
+            <binding>
+                <command>property-assign</command>
                 <property>/consumables/fuel/tank[0]/fuel-sample-taken</property>
                 <value>false</value>
             </binding>
@@ -155,7 +160,7 @@
                     <and>
                         <property>/consumables/fuel/tank[0]/fuel-sample-taken</property>
                         <equals>
-                            <property>/consumables/fuel/tank[0]/water-contamination</property>
+                            <property>/consumables/fuel/tank[0]/sample-water-contamination</property>
                             <value>0.0</value>
                         </equals>
                     </and>
@@ -174,13 +179,13 @@
                     <and>
                         <property>/consumables/fuel/tank[0]/fuel-sample-taken</property>
                         <greater-than>
-                            <property>/consumables/fuel/tank[0]/water-contamination</property>
+                            <property>/consumables/fuel/tank[0]/sample-water-contamination</property>
                             <value>0.0</value>
                         </greater-than>
-                        <less-than-equals>
-                            <property>/consumables/fuel/tank[0]/water-contamination</property>
+                        <less-than>
+                            <property>/consumables/fuel/tank[0]/sample-water-contamination</property>
                             <value>0.2</value>
-                        </less-than-equals>
+                        </less-than>
                     </and>
                 </visible>
                 <color>
@@ -197,13 +202,13 @@
                     <and>
                         <property>/consumables/fuel/tank[0]/fuel-sample-taken</property>
                         <greater-than>
-                            <property>/consumables/fuel/tank[0]/water-contamination</property>
+                            <property>/consumables/fuel/tank[0]/sample-water-contamination</property>
                             <value>0.0</value>
                         </greater-than>
-                        <less-than-equals>
-                            <property>/consumables/fuel/tank[0]/water-contamination</property>
+                        <less-than>
+                            <property>/consumables/fuel/tank[0]/sample-water-contamination</property>
                             <value>0.2</value>
-                        </less-than-equals>
+                        </less-than>
                     </and>
                 </visible>
                 <color>
@@ -219,10 +224,10 @@
                 <visible>
                     <and>
                         <property>/consumables/fuel/tank[0]/fuel-sample-taken</property>
-                        <greater-than>
-                            <property>/consumables/fuel/tank[0]/water-contamination</property>
+                        <equals>
+                            <property>/consumables/fuel/tank[0]/sample-water-contamination</property>
                             <value>0.2</value>
-                        </greater-than>
+                        </equals>
                     </and>
                 </visible>
                 <color>

--- a/gui/dialogs/c172p-right-fuel-sample.xml
+++ b/gui/dialogs/c172p-right-fuel-sample.xml
@@ -84,6 +84,11 @@
             </enable>
             <binding>
                 <command>property-assign</command>
+                <property>/consumables/fuel/tank[1]/sample-water-contamination</property>
+                <value>0.0</value>
+            </binding>
+            <binding>
+                <command>property-assign</command>
                 <property>/consumables/fuel/tank[1]/fuel-sample-taken</property>
                 <value>false</value>
             </binding>
@@ -155,7 +160,7 @@
                     <and>
                         <property>/consumables/fuel/tank[1]/fuel-sample-taken</property>
                         <equals>
-                            <property>/consumables/fuel/tank[1]/water-contamination</property>
+                            <property>/consumables/fuel/tank[1]/sample-water-contamination</property>
                             <value>0.0</value>
                         </equals>
                     </and>
@@ -174,13 +179,13 @@
                     <and>
                         <property>/consumables/fuel/tank[1]/fuel-sample-taken</property>
                         <greater-than>
-                            <property>/consumables/fuel/tank[1]/water-contamination</property>
+                            <property>/consumables/fuel/tank[1]/sample-water-contamination</property>
                             <value>0.0</value>
                         </greater-than>
-                        <less-than-equals>
-                            <property>/consumables/fuel/tank[1]/water-contamination</property>
+                        <less-than>
+                            <property>/consumables/fuel/tank[1]/sample-water-contamination</property>
                             <value>0.2</value>
-                        </less-than-equals>
+                        </less-than>
                     </and>
                 </visible>
                 <color>
@@ -197,13 +202,13 @@
                     <and>
                         <property>/consumables/fuel/tank[1]/fuel-sample-taken</property>
                         <greater-than>
-                            <property>/consumables/fuel/tank[1]/water-contamination</property>
+                            <property>/consumables/fuel/tank[1]/sample-water-contamination</property>
                             <value>0.0</value>
                         </greater-than>
-                        <less-than-equals>
-                            <property>/consumables/fuel/tank[1]/water-contamination</property>
+                        <less-than>
+                            <property>/consumables/fuel/tank[1]/sample-water-contamination</property>
                             <value>0.2</value>
-                        </less-than-equals>
+                        </less-than>
                     </and>
                 </visible>
                 <color>
@@ -219,10 +224,10 @@
                 <visible>
                     <and>
                         <property>/consumables/fuel/tank[1]/fuel-sample-taken</property>
-                        <greater-than>
-                            <property>/consumables/fuel/tank[1]/water-contamination</property>
+                        <equals>
+                            <property>/consumables/fuel/tank[1]/sample-water-contamination</property>
                             <value>0.2</value>
-                        </greater-than>
+                        </equals>
                     </and>
                 </visible>
                 <color>


### PR DESCRIPTION
Closes #902 

The fuel contamination system has been vastly improved with this PR:
- after taking a sample, the colour was shown according to the water _left_ in the tank instead of the water _in the sample itself_. This has been fixed
- so now in addition to `/consumables/fuel/tank[n]/water-contamination` we also have two properties `/consumables/fuel/tank[n]/sample-water-contamination` (for n = 0, 1). When water is present in the fuel and a sample is taken, the `water-contamination` diminishes by at most 0.2 and `sample-water-contamination` increases by that same amount. Then the colour is given according to the sample. Returning the sample reverses this process, discarding it resets the `sample-water-contamination`.