### PR TITLE
fixing oil temp and pressure gauges when complex procedures is false

### DIFF
--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -133,10 +133,13 @@ var oil_consumption = maketimer(1.0, func {
     }
 
     else {
+        # if oil consumption is not allowed, the oil level is set to full and pressure and temp factors are set to 1.0
         if (getprop("/controls/engines/active-engine") == 0)
             setprop("/engines/active-engine/oil-level", 7);
         if (getprop("/controls/engines/active-engine") == 1)
             setprop("/engines/active-engine/oil-level", 8);
+        setprop("/engines/active-engine/low-oil-pressure-factor", 1.0);
+        setprop("/engines/active-engine/low-oil-temperature-factor", 1.0);
     }
 });
 


### PR DESCRIPTION
Closes #916 

Now starting the sim with complex engine procedures set to `false` will not break the oil temp and pressure gauges. For testing purposes: if complex engine procedures is set to `true`, then toggle it to `false` and _restart  the sim_ to confirm everything works as fine, as the bug was present only when starting the sim with this property set to `false`)