### PR TITLE
Engine: Oil pressure at start, pressure vs RPM

### DIFF
--- a/Engines/eng_io320.xml
+++ b/Engines/eng_io320.xml
@@ -24,4 +24,5 @@
     <maxthrottle>               1.0  </maxthrottle>
     <minthrottle>               0.1  </minthrottle>
     <sparkfaildrop>             0.1 </sparkfaildrop>
+    <oil-pressure-rpm-max>      1215 </oil-pressure-rpm-max>
 </piston_engine>

--- a/Engines/eng_io360.xml
+++ b/Engines/eng_io360.xml
@@ -24,4 +24,5 @@
     <maxthrottle>               1.0  </maxthrottle>
     <minthrottle>               0.1  </minthrottle>
     <sparkfaildrop>             0.1 </sparkfaildrop>
+    <oil-pressure-rpm-max>      1215 </oil-pressure-rpm-max>
 </piston_engine>


### PR DESCRIPTION
Fixes #918 
**Necessitates a very recent FG version** (git 072bad4f50 from 27 April 2017) in which the oil pressure constants can be configured from the engine config file.