### PR TITLE
wing damage conditions, minor changes

### DIFF
--- a/Systems/c172p-damage.xml
+++ b/Systems/c172p-damage.xml
@@ -243,22 +243,20 @@
             <test logic="AND" value="1.0">
                 /velocities/airspeed-kt GT damage/limits-vne-high
             </test>
-            
+
             <test logic="AND" value="1.0">
                 /velocities/airspeed-kt GT damage/limits-vne-medium
-                damage/roll-moment GT 4000.0
-                wing-damage/right-wing LT 1.0
+                damage/roll-moment GT 12000.0
             </test>
 
             <!-- Over-g -->
             <test logic="AND" value="1.0">
                 damage/force-aero-lbs GT damage/limits-lift-high
             </test>
-            
+
             <test logic="AND" value="1.0">
                 damage/force-aero-lbs GT damage/limits-lift-medium
-                damage/roll-moment GT 4000.0
-                wing-damage/right-wing LT 1.0
+                damage/roll-moment GT 8000.0
             </test>
 
             <!-- ================================================================== -->
@@ -268,16 +266,16 @@
             <!-- Overspeed -->
             <test logic="AND" value="0.3">
                 /velocities/airspeed-kt GT damage/limits-vne-medium
-                damage/roll-moment LT 4000.0
-                damage/roll-moment GT -4000.0
+                damage/roll-moment LT 12000.0
+                damage/roll-moment GT -12000.0
                 wing-damage/left-wing LT 0.3
             </test>
 
             <!-- Over-g -->
             <test logic="AND" value="0.3">
                 damage/force-aero-lbs GT damage/limits-lift-medium
-                damage/roll-moment LT 4000.0
-                damage/roll-moment GT -4000.0
+                damage/roll-moment LT 8000.0
+                damage/roll-moment GT -8000.0
                 wing-damage/left-wing LT 0.3
             </test>
 
@@ -288,14 +286,14 @@
             <!-- Overspeed -->
             <test logic="AND" value="0.12">
                 /velocities/airspeed-kt GT damage/limits-vne-low
-                damage/roll-moment GT 4000.0
+                damage/roll-moment GT 8000.0
                 wing-damage/left-wing LT 0.12
             </test>
 
             <!-- Over-g -->
             <test logic="AND" value="0.12">
                 damage/force-aero-lbs GT damage/limits-lift-low
-                damage/roll-moment GT 4000.0
+                damage/roll-moment GT 8000.0
                 wing-damage/left-wing LT 0.12
             </test>
         </switch>
@@ -326,22 +324,20 @@
             <test logic="AND" value="1.0">
                 /velocities/airspeed-kt GT damage/limits-vne-high
             </test>
-            
+
             <test logic="AND" value="1.0">
                 /velocities/airspeed-kt GT damage/limits-vne-medium
-                damage/roll-moment LT -4000.0
-                wing-damage/left-wing LT 1.0
+                damage/roll-moment LT -12000.0
             </test>
 
             <!-- Over-g -->
             <test logic="AND" value="1.0">
                 damage/force-aero-lbs GT damage/limits-lift-high
             </test>
-            
+
             <test logic="AND" value="1.0">
                 damage/force-aero-lbs GT damage/limits-lift-medium
-                damage/roll-moment LT -4000.0
-                wing-damage/left-wing LT 1.0
+                damage/roll-moment LT -8000.0
             </test>
 
             <!-- ================================================================== -->
@@ -351,16 +347,16 @@
             <!-- Overspeed -->
             <test logic="AND" value="0.3">
                 /velocities/airspeed-kt GT damage/limits-vne-medium
-                damage/roll-moment LT 4000.0
-                damage/roll-moment GT -4000.0
+                damage/roll-moment LT 12000.0
+                damage/roll-moment GT -12000.0
                 wing-damage/right-wing LT 0.3
             </test>
             
             <!-- Over-g -->
             <test logic="AND" value="0.3">
                 damage/force-aero-lbs GT damage/limits-lift-medium
-                damage/roll-moment LT 4000.0
-                damage/roll-moment GT -4000.0
+                damage/roll-moment LT 8000.0
+                damage/roll-moment GT -8000.0
                 wing-damage/right-wing LT 0.3
             </test>
 
@@ -371,14 +367,14 @@
             <!-- Overspeed -->
             <test logic="AND" value="0.12">
                 /velocities/airspeed-kt GT damage/limits-vne-low
-                damage/roll-moment LT -4000.0
+                damage/roll-moment LT -8000.0
                 wing-damage/right-wing LT 0.12
             </test>
 
             <!-- Over-g -->
             <test logic="AND" value="0.12">
                 damage/force-aero-lbs GT damage/limits-lift-low
-                damage/roll-moment LT -4000.0
+                damage/roll-moment LT -8000.0
                 wing-damage/right-wing LT 0.12
             </test>
         </switch>

--- a/Systems/c172p-damage.xml
+++ b/Systems/c172p-damage.xml
@@ -159,16 +159,16 @@
 
         <!-- Limits for overspeed damage -->
         <pure_gain name="damage/limits-vne-high">
-            <input>/limits/vne</input>
-            <gain>1.225</gain>
+            <input>/limits/vne</input> 
+            <gain>1.225</gain> <!--  Vne x sqrt(1.5), 194 KIAS -->
         </pure_gain>
         <pure_gain name="damage/limits-vne-medium">
             <input>/limits/vne</input>
-            <gain>1.14</gain>
+            <gain>1.14</gain> <!-- 180 KIAS -->
         </pure_gain>
         <pure_gain name="damage/limits-vne-low">
             <input>/limits/vne</input>
-            <gain>1.0</gain>
+            <gain>1.0</gain> <!-- 158 KIAS -->
         </pure_gain>
 
         <!-- Limits for over-g damage, lift-force driven -->
@@ -243,38 +243,39 @@
             <test logic="AND" value="1.0">
                 /velocities/airspeed-kt GT damage/limits-vne-high
             </test>
+            
             <test logic="AND" value="1.0">
                 /velocities/airspeed-kt GT damage/limits-vne-medium
                 damage/roll-moment GT 4000.0
-                wing-damage/right-wing GT 0.0
+                wing-damage/right-wing LT 1.0
             </test>
 
             <!-- Over-g -->
             <test logic="AND" value="1.0">
                 damage/force-aero-lbs GT damage/limits-lift-high
             </test>
+            
             <test logic="AND" value="1.0">
                 damage/force-aero-lbs GT damage/limits-lift-medium
                 damage/roll-moment GT 4000.0
                 wing-damage/right-wing LT 1.0
-                wing-damage/right-wing GT 0.0
             </test>
 
             <!-- ================================================================== -->
             <!-- Heavy damage                                                       -->
             <!-- ================================================================== -->
 
-            <!-- Over-g -->
+            <!-- Overspeed -->
             <test logic="AND" value="0.3">
-                damage/force-aero-lbs GT damage/limits-lift-medium
+                /velocities/airspeed-kt GT damage/limits-vne-medium
                 damage/roll-moment LT 4000.0
                 damage/roll-moment GT -4000.0
                 wing-damage/left-wing LT 0.3
             </test>
 
-            <!-- Overspeed -->
+            <!-- Over-g -->
             <test logic="AND" value="0.3">
-                /velocities/airspeed-kt GT damage/limits-vne-medium
+                damage/force-aero-lbs GT damage/limits-lift-medium
                 damage/roll-moment LT 4000.0
                 damage/roll-moment GT -4000.0
                 wing-damage/left-wing LT 0.3
@@ -288,20 +289,14 @@
             <test logic="AND" value="0.12">
                 /velocities/airspeed-kt GT damage/limits-vne-low
                 damage/roll-moment GT 4000.0
-                wing-damage/left-wing EQ 0.0
+                wing-damage/left-wing LT 0.12
             </test>
 
             <!-- Over-g -->
             <test logic="AND" value="0.12">
-                damage/force-aero-lbs GT damage/limits-lift-medium
-                damage/roll-moment LT 4000.0
-                damage/roll-moment GT -4000.0
-                wing-damage/left-wing EQ 0.0
-            </test>
-            <test logic="AND" value="0.12">
                 damage/force-aero-lbs GT damage/limits-lift-low
                 damage/roll-moment GT 4000.0
-                wing-damage/left-wing EQ 0.0
+                wing-damage/left-wing LT 0.12
             </test>
         </switch>
 
@@ -331,38 +326,39 @@
             <test logic="AND" value="1.0">
                 /velocities/airspeed-kt GT damage/limits-vne-high
             </test>
+            
             <test logic="AND" value="1.0">
                 /velocities/airspeed-kt GT damage/limits-vne-medium
                 damage/roll-moment LT -4000.0
-                wing-damage/left-wing GT 0.0
+                wing-damage/left-wing LT 1.0
             </test>
 
             <!-- Over-g -->
             <test logic="AND" value="1.0">
                 damage/force-aero-lbs GT damage/limits-lift-high
             </test>
+            
             <test logic="AND" value="1.0">
                 damage/force-aero-lbs GT damage/limits-lift-medium
                 damage/roll-moment LT -4000.0
                 wing-damage/left-wing LT 1.0
-                wing-damage/left-wing GT 0.0
             </test>
 
             <!-- ================================================================== -->
             <!-- Heavy damage                                                       -->
             <!-- ================================================================== -->
 
-            <!-- Over-g -->
+            <!-- Overspeed -->
             <test logic="AND" value="0.3">
-                damage/force-aero-lbs GT damage/limits-lift-medium
+                /velocities/airspeed-kt GT damage/limits-vne-medium
                 damage/roll-moment LT 4000.0
                 damage/roll-moment GT -4000.0
                 wing-damage/right-wing LT 0.3
             </test>
-
-            <!-- Overspeed -->
+            
+            <!-- Over-g -->
             <test logic="AND" value="0.3">
-                /velocities/airspeed-kt GT damage/limits-vne-medium
+                damage/force-aero-lbs GT damage/limits-lift-medium
                 damage/roll-moment LT 4000.0
                 damage/roll-moment GT -4000.0
                 wing-damage/right-wing LT 0.3
@@ -376,20 +372,14 @@
             <test logic="AND" value="0.12">
                 /velocities/airspeed-kt GT damage/limits-vne-low
                 damage/roll-moment LT -4000.0
-                wing-damage/right-wing EQ 0.0
+                wing-damage/right-wing LT 0.12
             </test>
 
             <!-- Over-g -->
             <test logic="AND" value="0.12">
-                damage/force-aero-lbs GT damage/limits-lift-medium
-                damage/roll-moment LT 4000.0
-                damage/roll-moment GT -4000.0
-                wing-damage/right-wing EQ 0.0
-            </test>
-            <test logic="AND" value="0.12">
                 damage/force-aero-lbs GT damage/limits-lift-low
                 damage/roll-moment LT -4000.0
-                wing-damage/right-wing EQ 0.0
+                wing-damage/right-wing LT 0.12
             </test>
         </switch>
 

--- a/Systems/c172p-damage.xml
+++ b/Systems/c172p-damage.xml
@@ -351,7 +351,7 @@
                 damage/roll-moment GT -12000.0
                 wing-damage/right-wing LT 0.3
             </test>
-            
+
             <!-- Over-g -->
             <test logic="AND" value="0.3">
                 damage/force-aero-lbs GT damage/limits-lift-medium

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -881,9 +881,6 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 
         <vne>158</vne>
 
-        <!-- 2550*3.8 -->
-        <max-lift-force>9690</max-lift-force>
-
         <mass-and-balance-160hp>
             <maximum-ramp-mass-lbs>2407</maximum-ramp-mass-lbs>
             <maximum-takeoff-mass-lbs>2400</maximum-takeoff-mass-lbs>


### PR DESCRIPTION
I changed a few lines (logic criteria) in the wing damage conditions. Unless I didn't understand the initial logic behind, I thought that some conditions seemed inappropriate.

I think so but I hope that it works as expected, because checking the over-g values in flight is rather hard. Moreover there are many possibilities / combinations (velocities, g-overload, roll moment).

No fundamental change, only (I hope) a refinement.
