### PR TITLE
Bug 789 - Create a save mission state that includes position, orientation and heading 

### DIFF
--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -376,6 +376,7 @@ var thunder = func (name) {
     }, delay_seconds);
 };
 
+var persistent = getprop("/sim/model/c172p/persistent");
 var reset_system = func {
     if (getprop("/fdm/jsbsim/running")) {
         c172p.autostart(0);
@@ -393,6 +394,13 @@ var reset_system = func {
     props.globals.getNode("/fdm/jsbsim/pontoon-damage/right-pontoon", 0).setIntValue(0);
 
     setprop("/engines/active-engine/kill-engine", 0);
+
+    if (persistent) {
+        setprop("position/latitude-deg", getprop("/sim/model/c172p/currentlat"));
+        setprop("position/longitude-deg", getprop("/sim/model/c172p/currentlon"));
+        setprop("position/altitude-ft", getprop("/sim/model/c172p/currentalt"));
+        setprop("orientation/heading-deg", getprop("/sim/model/c172p/currenthead"));
+    }
 }
 
 ############################################
@@ -470,6 +478,14 @@ ad_timer.start();
 ############################################
 var global_system_loop = func {
     c172p.physics_loop();
+
+    persistent = getprop("/sim/model/c172p/persistent");
+    if (persistent) {
+        setprop("/sim/model/c172p/currentlat", getprop("/position/latitude-deg"));
+        setprop("/sim/model/c172p/currentlon", getprop("/position/longitude-deg"));
+        setprop("/sim/model/c172p/currentalt", getprop("/position/altitude-ft"));
+        setprop("/sim/model/c172p/currenthead", getprop("/orientation/heading-deg"));
+    }
 }
 
 ##########################################

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -399,6 +399,10 @@ var reset_system = func {
         setprop("position/longitude-deg", getprop("/sim/model/c172p/currentlon"));
         setprop("position/altitude-ft", getprop("/sim/model/c172p/currentalt"));
         setprop("orientation/heading-deg", getprop("/sim/model/c172p/currenthead"));
+        setprop("orientation/pitch-deg", getprop("/sim/model/c172p/currentpitch"));
+        setprop("orientation/roll-deg", getprop("/sim/model/c172p/currentroll"));
+        setprop("velocities/vertical-speed-fps", getprop("/sim/model/c172p/currentvsfps"));
+        setprop("velocities/equivalent-kt", getprop("/sim/model/c172p/currenteqnt"));
     }
 }
 
@@ -483,6 +487,10 @@ var global_system_loop = func {
         setprop("/sim/model/c172p/currentlon", getprop("/position/longitude-deg"));
         setprop("/sim/model/c172p/currentalt", getprop("/position/altitude-ft"));
         setprop("/sim/model/c172p/currenthead", getprop("/orientation/heading-deg"));
+        setprop("/sim/model/c172p/currentpitch", getprop("/orientation/pitch-deg"));
+        setprop("/sim/model/c172p/currentroll", getprop("orientation/roll-deg"));
+        setprop("/sim/model/c172p/currentvsfps", getprop("velocities/vertical-speed-fps"));
+        setprop("/sim/model/c172p/currenteqnt", getprop("velocities/equivalent-kt"));
     }
 }
 

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -376,7 +376,6 @@ var thunder = func (name) {
     }, delay_seconds);
 };
 
-var persistent = getprop("/sim/model/c172p/persistent");
 var reset_system = func {
     if (getprop("/fdm/jsbsim/running")) {
         c172p.autostart(0);
@@ -395,7 +394,7 @@ var reset_system = func {
 
     setprop("/engines/active-engine/kill-engine", 0);
 
-    if (persistent) {
+    if (getprop("/fdm/jsbsim/position/persistent")) {
         setprop("position/latitude-deg", getprop("/sim/model/c172p/currentlat"));
         setprop("position/longitude-deg", getprop("/sim/model/c172p/currentlon"));
         setprop("position/altitude-ft", getprop("/sim/model/c172p/currentalt"));
@@ -479,8 +478,7 @@ ad_timer.start();
 var global_system_loop = func {
     c172p.physics_loop();
 
-    persistent = getprop("/sim/model/c172p/persistent");
-    if (persistent) {
+    if (getprop("/fdm/jsbsim/position/persistent-state")) {
         setprop("/sim/model/c172p/currentlat", getprop("/position/latitude-deg"));
         setprop("/sim/model/c172p/currentlon", getprop("/position/longitude-deg"));
         setprop("/sim/model/c172p/currentalt", getprop("/position/altitude-ft"));

--- a/Systems/c172p-persistent.xml
+++ b/Systems/c172p-persistent.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright (c) 2017 wlbragg
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<system name="c172p persistent">
+
+    <channel name="persistent-position">
+
+        <switch name="undercarriage-wow">
+            <output>contact/wow</output>
+            <default value="0"/>
+
+            <!-- undercarriage wow -->
+            <test logic="OR" value="1">
+                gear/wow EQ 1
+                contact/unit[13]/WOW EQ 1
+                contact/unit[14]/WOW EQ 1
+                contact/unit[15]/WOW EQ 1
+                contact/unit[16]/WOW EQ 1
+            </test>
+        </switch>
+
+        <switch name="persistent-speed">
+            <output>position/persistent-speed</output>
+            <default value="0"/>
+
+            <test logic="AND" value="1">
+                /velocities/groundspeed-kt LT 1
+            </test>
+        </switch>
+
+        <fcs_function name="position/persistent">
+            <function>
+                <product>
+                    <property>/sim/model/c172p/persistent</property>
+                    <property>/fdm/jsbsim/contact/wow</property>
+                </product>
+            </function>
+        </fcs_function>
+
+        <fcs_function name="position/persistent-state">
+            <function>
+                <product>
+                    <property>/fdm/jsbsim/position/persistent</property>
+                    <property>/fdm/jsbsim/position/persistent-speed</property>
+                </product>
+            </function>
+        </fcs_function>
+
+    </channel>
+
+</system>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -213,6 +213,10 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
                 <currentlon type="double">0.0</currentlon>
                 <currentalt type="double">0.0</currentalt>
                 <currenthead type="double">0.0</currenthead>
+                <currentpitch type="double">0.0</currentpitch>
+                <currentroll type="double">0.0</currentroll>
+                <currentvsfps type="double">0.0</currentvsfps>
+                <currenteqnt type="double">0.0</currenteqnt>
 
             </c172p>
 
@@ -291,6 +295,10 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <path>/sim/model/c172p/currentlon</path>
             <path>/sim/model/c172p/currentalt</path>
             <path>/sim/model/c172p/currenthead</path>
+            <path>/sim/model/c172p/currentpitch</path>
+            <path>/sim/model/c172p/currentroll</path>
+            <path>/sim/model/c172p/currentvsfps</path>
+            <path>/sim/model/c172p/currenteqnt</path>
         </aircraft-data>
 
         <current-view>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -208,7 +208,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
                 
                 <save-state type="bool">false</save-state>
                 
-                <persistent type="bool">0</persistent>
+                <persistent type="bool">false</persistent>
                 <currentlat type="double">0.0</currentlat>
                 <currentlon type="double">0.0</currentlon>
                 <currentalt type="double">0.0</currentalt>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -208,6 +208,12 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
                 
                 <save-state type="bool">false</save-state>
                 
+                <persistent type="bool">0</persistent>
+                <currentlat type="double">0.0</currentlat>
+                <currentlon type="double">0.0</currentlon>
+                <currentalt type="double">0.0</currentalt>
+                <currenthead type="double">0.0</currenthead>
+
             </c172p>
 
             <hide-yoke type="bool">false</hide-yoke>
@@ -280,6 +286,11 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <path>/sim/model/c172p/save-state</path>
             <path>/engines/active-engine/complex-engine-procedures</path>
             <path>/sim/model/immat</path>
+            <path>/sim/model/c172p/persistent</path>
+            <path>/sim/model/c172p/currentlat</path>
+            <path>/sim/model/c172p/currentlon</path>
+            <path>/sim/model/c172p/currentalt</path>
+            <path>/sim/model/c172p/currenthead</path>
         </aircraft-data>
 
         <current-view>

--- a/c172p.xml
+++ b/c172p.xml
@@ -1875,6 +1875,7 @@
     <system file="c172p-damage"/>
     <system file="c172p-sounds"/>
     <system file="c172p-heat"/>
+    <system file="c172p-persistent"/>
     <system file="indicated-airspeed"/>
 
     <!--

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -88,6 +88,16 @@
                     <command>dialog-apply</command>
                 </binding>
             </checkbox>
+
+            <checkbox>
+                <halign>left</halign>
+                <label>Persistent position</label>
+                <property>/sim/model/c172p/persistent</property>
+                <live>true</live>
+                <binding>
+                    <command>dialog-apply</command>
+                </binding>
+            </checkbox>
             
             <checkbox>
                 <halign>left</halign>


### PR DESCRIPTION
This is so simple to do. I can't believe it took this long for us to attempt to implement. It should fit nicely with the "save state of aircraft between sessions".

I am also implementing this on the AirCrane and the J3Cub.

Fixes #789 