### PR TITLE
No lighting on pontoon wake effect. Eliminate wingtip and tail sparks…

### DIFF
--- a/Models/Effects/pontoon/left-wake.xml
+++ b/Models/Effects/pontoon/left-wake.xml
@@ -15,7 +15,7 @@
         <name>right-wake</name>
         <texture>wake.png</texture>
         <emissive>false</emissive>
-        <lighting>true</lighting>
+        <lighting>false</lighting>
 
         <condition>
             <and>

--- a/Models/Effects/pontoon/middle-wake.xml
+++ b/Models/Effects/pontoon/middle-wake.xml
@@ -15,7 +15,7 @@
         <name>middle-wake</name>
         <texture>wake.png</texture>
         <emissive>false</emissive>
-        <lighting>true</lighting>
+        <lighting>false</lighting>
 
         <condition>
             <greater-than>

--- a/Models/Effects/pontoon/right-wake.xml
+++ b/Models/Effects/pontoon/right-wake.xml
@@ -15,7 +15,7 @@
         <name>right-wake</name>
         <texture>wake.png</texture>
         <emissive>false</emissive>
-        <lighting>true</lighting>
+        <lighting>false</lighting>
 
         <condition>
             <and>

--- a/Systems/c172p-ground-effects.xml
+++ b/Systems/c172p-ground-effects.xml
@@ -358,6 +358,7 @@
             <function>
                 <product>
                     <property>/fdm/jsbsim/contact/unit[3]/WOW</property>
+                    <property>/fdm/jsbsim/ground/solid</property>
                     <property>/velocities/groundspeed-kt</property>
                 </product>
             </function>
@@ -367,6 +368,7 @@
             <function>
                 <product>
                     <property>/fdm/jsbsim/contact/unit[4]/WOW</property>
+                    <property>/fdm/jsbsim/ground/solid</property>
                     <property>/velocities/groundspeed-kt</property>
                     <eq>
                         <property>/fdm/jsbsim/wing-damage/left-wing</property>
@@ -380,6 +382,7 @@
             <function>
                 <product>
                     <property>/fdm/jsbsim/contact/unit[5]/WOW</property>
+                    <property>/fdm/jsbsim/ground/solid</property>
                     <property>/velocities/groundspeed-kt</property>
                     <eq>
                         <property>/fdm/jsbsim/wing-damage/right-wing</property>


### PR DESCRIPTION
I recently discovered this bug on the wingtip sparks. It makes no sense to me that it sparked when the condition for sparks was a product of contact[]/wow. When over water contact[0]/wow is always = to 0. A product with 0 in the equation should always equal 0. But none the less, we had sparks on the water. By adding fdm/jsbsim/position/solid to the product, it eliminated the sparks when over water but not when over land.

The lighting in all pray spray effects should be false.