### PR TITLE
Bug 976: Fix applying effect to renamed object 'extinguisher'

### DIFF
--- a/Models/Interior/FE-ELT/fe2.xml
+++ b/Models/Interior/FE-ELT/fe2.xml
@@ -3,13 +3,10 @@
 <PropertyList>
 
     <path>fe2.ac</path>
+
     <effect>
         <inherits-from>../../Effects/interior/c172p-interior</inherits-from>
-        <object-name>extinguisher2</object-name>
+        <object-name>extinguisher</object-name>
     </effect>
-
-    <animation>
-        <object-name>extinguisher2</object-name>
-    </animation>
 
 </PropertyList>


### PR DESCRIPTION
Fixes #976 

Prevents FG printing `Could not find at least one of the following objects for animation: 'extinguisher2'` to the console. Interior effect should be applied again.