### PR TITLE
Add force and moment induced by AI wakes.

### DIFF
--- a/c172p.xml
+++ b/c172p.xml
@@ -1901,12 +1901,12 @@
             </direction>
         </force>
         <force name="ai-wake" frame="BODY">
-          <location unit="IN">
-            <!-- Center of the main wing leading edge -->
-            <x>-4.7</x>
-            <y> 0.0</y>
-            <z>50.0</z>
-          </location>
+            <location unit="IN">
+                <!-- Center of the main wing leading edge -->
+                <x>32.0</x>
+                <y> 0.0</y>
+                <z>52.5</z>
+            </location>
         </force>
         <moment name="ai-wake" frame="BODY"/>
     </external_reactions>

--- a/c172p.xml
+++ b/c172p.xml
@@ -1900,6 +1900,15 @@
                 <z>1.0</z>
             </direction>
         </force>
+        <force name="ai-wake" frame="BODY">
+          <location unit="IN">
+            <!-- Center of the main wing leading edge -->
+            <x>-4.7</x>
+            <y> 0.0</y>
+            <z>50.0</z>
+          </location>
+        </force>
+        <moment name="ai-wake" frame="BODY"/>
     </external_reactions>
 
     <system file="bushkit"/>


### PR DESCRIPTION
Hi there,

I added a feature to FlightGear v2017.3.1 that allows aerodynamic interaction between the aircraft and AI models. The feature is briefly described in a [dedicated article](http://wiki.flightgear.org/AI_wake_turbulence) in the FlightGear wiki.

All you need is to add external reactions that models the induced aerodynamics loads on the aircraft. The resultant force and moment will superpose to the rest of the forces and moments computed by the FDM.

The computations made by FlightGear assume that the force is located at the intersection between the main wing leading edge and the aircraft plane of symmetry. This is important for the resulting moment to be correctly computed. I tried to estimate that position for the c172p at x=-4.7in and z=50in but this might not be quite accurate. Let me know if that needs some correction.

The c172p being the flagship of FlightGear I would be honored that you include that feature as an example for other aircrafts modelers.

Thanks.