### PR TITLE
Fix wrong production year in xml files

### DIFF
--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -19,7 +19,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 <PropertyList include="Aircraft/Generic/Human/Include/walker-include.xml">
 
     <sim include="c172p-views.xml">
-        <description>Cessna 172P Skyhawk (1981 model, detailed)</description>
+        <description>Cessna 172P Skyhawk (1982)</description>
 
         <long-description>The Cessna 172 Skyhawk is a four-seat, single-engine, high-wing fixed-wing aircraft. First flown in 1955 and still in production, more Cessna 172s have been built than any other aircraft.</long-description>
 

--- a/c172p.xml
+++ b/c172p.xml
@@ -13,7 +13,7 @@
         <!-- Source: http://forum.flightgear.org/viewtopic.php?f=25&t=21664&start=45 -->
         <!-- this file with comments for stall and spin to help -->
         <!-- further modifications for c172p-detailed 2015 - 2018 -->
-        <description> Cessna C-172 </description>
+        <description> Cessna 172P Skyhawk </description>
     </fileheader>
 
     <metrics>


### PR DESCRIPTION
Fixes #985 

* Fix wrong production year in `c172p-set.xml`
* Removed the word `detailed` from the description in `c172p-set.xml` as this has become the de-facto default aircraft and not a separate "detailed" model which would need to be differentiated
* Improves description in `c172p.xml`, as `Cessna 172P Skyhawk` is better than `Cessna C-172`