### PR TITLE
Add keyboard shortcut for the flashlight

### DIFF
--- a/c172p-keyboard.xml
+++ b/c172p-keyboard.xml
@@ -47,6 +47,16 @@
         </binding>
     </key>
 
+    <key n="102">
+        <name>f</name>
+        <desc>Toggle flashlight</desc>
+        <repeatable type="bool">true</repeatable>
+        <binding>
+            <command>nasal</command>
+            <script>c172p.toggle_flashlight()</script>
+        </binding>
+    </key>
+
     <key n="108">
         <name>l</name>
         <desc>Increase Panel lighting</desc>


### PR DESCRIPTION
I don't know if this change is acceptable upstream or useful to other people, but it has been very useful to me in night flights.