### PR TITLE
Fix VSI interpolation to match texture, number autopilots in -set

### DIFF
--- a/Models/Interior/Panel/Instruments/VSI/VSI.xml
+++ b/Models/Interior/Panel/Instruments/VSI/VSI.xml
@@ -32,19 +32,19 @@
         <interpolation>
             <entry>
                 <ind>-2000</ind>
-                <dep>-172</dep>
+                <dep>-176</dep>
             </entry>
             <entry>
                 <ind>-1500</ind>
-                <dep>-130</dep>
+                <dep>-133</dep>
             </entry>
             <entry>
                 <ind>-1000</ind>
-                <dep>-79</dep>
+                <dep>-88</dep>
             </entry>
             <entry>
                 <ind>-500</ind>
-                <dep>-33</dep>
+                <dep>-44</dep>
             </entry>
             <entry>
                 <ind>0</ind>
@@ -52,19 +52,19 @@
             </entry>
             <entry>
                 <ind>500</ind>
-                <dep>33</dep>
+                <dep>44</dep>
             </entry>
             <entry>
                 <ind>1000</ind>
-                <dep>79</dep>
+                <dep>88</dep>
             </entry>
             <entry>
                 <ind>1500</ind>
-                <dep>130</dep>
+                <dep>133</dep>
             </entry>
             <entry>
                 <ind>2000</ind>
-                <dep>172</dep>
+                <dep>176</dep>
             </entry>
         </interpolation>
         <axis>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -348,13 +348,13 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
         <systems>
             <path>Aircraft/c172p/Systems/systems.xml</path>
 
-            <autopilot>
+            <autopilot n="0">
                 <path>Systems/KAP140.xml</path>
             </autopilot>
-            <autopilot>
+            <autopilot n="1">
                 <path>Systems/glass-rain.xml</path>
             </autopilot>
-            <autopilot>
+            <autopilot n="2">
                 <path>Systems/control-lock.xml</path>
             </autopilot>
 


### PR DESCRIPTION
This fixes the needle not pointing to the right numbers, and numbers the autopilots in the -set file.

Any questions just ask. This *does not* include my AP rework since that is not ready yet.

Kind Regards,
Josh