### PR TITLE
mooring-system-update

### DIFF
--- a/Nasal/mooring.nas
+++ b/Nasal/mooring.nas
@@ -20,9 +20,25 @@
 #init if allowed and called for
 setlistener("/sim/signals/fdm-initialized",
     func {
-        if (getprop("/controls/mooring/automatic") and getprop("/controls/mooring/allowed")) {
-            seaplane = Mooring.new();
+
+        var presets = props.globals.getNode("/sim/presets");
+        var seaplanes = props.globals.getNode("/systems/mooring/route").getChildren("seaplane");
+        var harbour = "";
+        var airport = presets.getChild("airport-id").getValue();
+        setprop("/controls/mooring/port-available", 0);
+        if(airport != nil and airport != "") {
+            for(var i=0; i<size(seaplanes); i=i+1) {
+                harbour = seaplanes[ i ].getChild("airport-id").getValue();
+                if(harbour == airport) {
+                    setprop("/controls/mooring/port-available", 1);
+                }
+            }
         }
+        settimer(func{
+            if (getprop("/controls/mooring/automatic") and getprop("/controls/mooring/allowed")) {
+                seaplane = Mooring.new();
+            }
+        },1.0);
     }
 );
 setlistener("/controls/mooring/go-to-mooring",

--- a/Systems/bushkit.xml
+++ b/Systems/bushkit.xml
@@ -355,7 +355,8 @@ Extra weight and drag due to bush wheels, floats and aircraft with 180 hp engine
             <test logic="AND" value="1">
                 bushkit GE 3
                 bushkit LE 4
-                /velocities/groundspeed-kt LE 1
+                /controls/mooring/port-available EQ 1
+                hydro/active-norm EQ 0
             </test>
             <output>/controls/mooring/allowed</output>
         </switch>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -570,6 +570,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <automatic type="bool">false</automatic>
             <anchor type="bool">false</anchor>
             <go-to-mooring type="bool">false</go-to-mooring>
+            <port-available type="bool">false</port-available>
         </mooring>
     </controls>
 

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -113,15 +113,6 @@
                 <binding>
                     <command>dialog-apply</command>
                 </binding>
-                <binding>
-                    <command>nasal</command>
-                    <script>
-                        c172p.repair_damage();
-                        electrical.reset_battery_and_circuit_breakers();
-                        c172p.click("engine-repair", 6.0);
-                        c172p.dialog_battery_reload();
-                    </script>
-                </binding>
             </checkbox>
 
             <button>
@@ -131,7 +122,6 @@
                 <pref-height>28</pref-height>
                 <enable>
                     <and>
-                        <property>/fdm/jsbsim/settings/damage</property>
                         <not>
                             <property>/sim/freeze/replay-state</property>
                         </not>
@@ -831,19 +821,10 @@
                 <pref-height>28</pref-height>
                 <enable>
                     <and>
+                        <property>/controls/mooring/allowed</property>
                         <not>
                             <property>/sim/freeze/replay-state</property>
                         </not>
-                        <or>
-                            <equals>
-                                <property>/fdm/jsbsim/bushkit</property>
-                                <value>3</value>
-                            </equals>
-                            <equals>
-                                <property>/fdm/jsbsim/bushkit</property>
-                                <value>4</value>
-                            </equals>
-                        </or>
                     </and>
                 </enable>
                 <binding>


### PR DESCRIPTION
@onox this fixes the inconsistent spawning behavior. You may have thought that was fixed but it wasn't. I had a speed limit condition on the "mooring-allowed" flag that would allow auto spawning on startup but it was killing the spawning from the "Go to airport" GUI reposition system. Anyway that is fixed. I also figured out a way to limit the "Go now" button's availability.

Please test and merge when ready.