### PR TITLE
Issue 1076: Improve DME clickspots

### DIFF
--- a/Models/Interior/Panel/Instruments/dme/dme.xml
+++ b/Models/Interior/Panel/Instruments/dme/dme.xml
@@ -54,45 +54,7 @@
 
     <animation>
         <type>pick</type>
-        <object-name>on</object-name>
-        <visible>true</visible>
-        <action>
-            <button>0</button>
-            <repeatable>false</repeatable>
-            <binding>
-                <command>property-assign</command>
-                <property alias="../../../../params/power-btn"/>
-                <value>1</value>
-            </binding>
-            <binding>
-                <command>nasal</command>
-                <script>c172p.click("dme-power")</script>
-            </binding>
-        </action>
-    </animation>
-
-    <animation>
-        <type>pick</type>
-        <object-name>off</object-name>
-        <visible>true</visible>
-        <action>
-            <button>0</button>
-            <repeatable>false</repeatable>
-            <binding>
-                <command>property-assign</command>
-                <property alias="../../../../params/power-btn"/>
-                <value>0</value>
-            </binding>
-            <binding>
-                <command>nasal</command>
-                <script>c172p.click("dme-power")</script>
-            </binding>
-        </action>
-    </animation>
-
-    <animation>
-        <type>pick</type>
-        <object-name>PowerSwitch</object-name>
+        <object-name>PowerSwitch.Lever</object-name>
         <visible>true</visible>
         <action>
             <button>0</button>

--- a/Models/Interior/Panel/Instruments/dme/dme.xml
+++ b/Models/Interior/Panel/Instruments/dme/dme.xml
@@ -20,8 +20,6 @@
 
     <effect>
         <inherits-from>../../../../Effects/interior/c172p-interior</inherits-from>
-        <object-name>on</object-name>
-        <object-name>off</object-name>
         <object-name>Label3</object-name>
         <object-name>n1</object-name>
         <object-name>hld</object-name>
@@ -54,7 +52,7 @@
 
     <animation>
         <type>pick</type>
-        <object-name>PowerSwitch.Lever</object-name>
+        <object-name>PowerSwitch</object-name>
         <visible>true</visible>
         <action>
             <button>0</button>

--- a/Models/Interior/Panel/Instruments/dme/ki266.xml
+++ b/Models/Interior/Panel/Instruments/dme/ki266.xml
@@ -144,8 +144,6 @@
     <animation>
         <type>pick</type>
         <object-name>ModeSwitch</object-name>
-        <object-name>Min</object-name>
-        <object-name>Kts</object-name>
         <visible>true</visible>
         <action>
             <button>0</button>


### PR DESCRIPTION
Fixes #1076

- Removed the clickspots on the on/off labels of the DME-power-switch and replaced it by the real switch.
- Removed clickspots on KTS/MIN labels. The button for that is already correctly implemented.
